### PR TITLE
Pin docker image to 0.0.318

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.service.opg.digital/opg-php-fpm-1604
+FROM registry.service.opg.digital/opg-php-fpm-1604:0.0.318
 
 RUN  cd /tmp && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
Starfox needs to update the base images for the Sirius ECS migration. I've pinned all the refunds version to the latest version in master before our upgrade.